### PR TITLE
Add automated uf2 builds using GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
           submodules: recursive
 
       - name: Install toolchain
-        run: sudo apt install -y gcc-arm-none-eabi
+        run: sudo apt-get install -y gcc-arm-none-eabi
       
       - name: Build
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,9 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: recursive
+
+      - name: Install toolchain
+        run: sudo apt install -y gcc-arm-none-eabi
       
       - name: Build
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,30 @@
+name: Build
+
+on:
+  push:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        board: [pico, pico_w, pico2, pico2_w, waveshare_rp2350_usb_a]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+      
+      - name: Build
+        run: |
+          mkdir build
+          cd build
+          export PICO_SDK_PATH=../pico-sdk
+          cmake ../src -DPICO_BOARD=${{ matrix.board }}
+          make -j4
+
+      - name: Upload uf2
+        uses: actions/upload-artifact@v7
+        with:
+          name: PicoGamepadConverter-${{ matrix.board }}
+          path: build/PicoGamepadConverter.uf2

--- a/src/convert_data.c
+++ b/src/convert_data.c
@@ -9,6 +9,7 @@
 #if PICO_W
     #include "bluetooth_descriptors.h"
     #include "wiimote.h"
+    #include "wm_reports.h"
 #endif
 //Host
 #include "xinput_definitions.h"
@@ -21,7 +22,6 @@
 
 #include <stdio.h>
 #include "utils.h"
-#include "wm_reports.h"
 #include "pico/flash.h"
 
 //Definitions


### PR DESCRIPTION
GitHub Actions could also be used to automate release creation, but I didn't implement that.

This PR also fixes a compilation error on non-wireless boards.

You can see an example of the action running and the uploaded artifacts here: https://github.com/amsam0/PicoGamepadConverter/actions/runs/27562406753